### PR TITLE
handling breaks in shifts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1555,9 +1555,9 @@
       }
     },
     "@mapbox/node-pre-gyp": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.9.tgz",
-      "integrity": "sha512-aDF3S3rK9Q2gey/WAttUlISduDItz5BU3306M9Eyv6/oS40aMprnopshtlKTykxRNIBEZuRMaZAnbrQ4QtKGyw==",
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.10.tgz",
+      "integrity": "sha512-4ySo4CjzStuprMwk35H5pPbkymjv1SF3jGLj6rAHp/xT/RF7TL7bd9CTm1xDY49K2qF7jmR/g7k+SkLETP6opA==",
       "requires": {
         "detect-libc": "^2.0.0",
         "https-proxy-agent": "^5.0.0",

--- a/src/services/zendesk/selectAgentToAssign.ts
+++ b/src/services/zendesk/selectAgentToAssign.ts
@@ -11,47 +11,55 @@ const selectAgentToAssign = async (agents: Agent[], getLastAssignedAgentId: Func
 
     //get hour and minute in UTC
     const currentDate = new Date();
-    const currentHour = currentDate.getUTCHours();    
+    const currentHour = currentDate.getUTCHours();
     const currentMinute = currentDate.getUTCMinutes();
 
     let currentlyAvailableAgents = [];
     //first select the agents available at the current hour
-    for (let agent in agents) {       
+    for (let agent in agents) {
 
         //if in the array of available agents we have a name of the agent that was returned Zendesk - get his working hours
         if (shiftSchedule.agents.find(e => e === agents[agent].name)) {
             //extract agent from the shift rota array
             const agentPositionInArray = shiftSchedule.agents.indexOf(agents[agent].name);
-            //extract the shift start and end hours to two-element array
-            const agentShiftLimits = shiftSchedule.hours[agentPositionInArray].split('-');
 
-            //get CET hours and decrement to get UTC hours -> here daylight saving time handling should be added
-            const agentStartTime = parseInt(agentShiftLimits[0]) - 1;
-            const agentEndTime = parseInt(agentShiftLimits[1]) - 1;
+            //extract periods for which the agent works in the day - they are stored as semicolon-separated values in the database 
+            //8-10;12-16 means agent works from 8 to 10 and then from 12 to 16
+            const agentShiftPeriods = shiftSchedule.hours[agentPositionInArray].split(';');
 
-            //check if the agent works at the moment with 30 minute offset (so agent working till 5pm will get the tickets assigned till 4:30pm) - if yes then push him to the array
-            //agents working till 10pm are getting the tickets assigned till the end of the shift
-            if (agentStartTime <= currentHour && 
-                    (agentEndTime - 1 > currentHour || 
-                    (agentEndTime - 1 === currentHour && currentMinute < 30) || 
-                    //below we check if end hour is 10PM CET - but it is 9PM UTC, thus 'agentEndTime  === 21'
-                    (agentEndTime  === 21 && currentHour === 20))) 
+            //for each worktime period - define if the agent is eligible for ticket assignments
+            for (let period of agentShiftPeriods) {
+                //extract the shift start and end hours to two-element array
+                const agentShiftLimits = period.split('-');
+
+                //get CET hours and decrement to get UTC hours -> here daylight saving time handling should be added
+                const agentStartTime = parseInt(agentShiftLimits[0]) - 1;
+                const agentEndTime = parseInt(agentShiftLimits[1]) - 1;
+
+                //check if the agent works at the moment with 30 minute offset (so agent working till 5pm will get the tickets assigned till 4:30pm) - if yes then push him to the array
+                //agents working till 10pm are getting the tickets assigned till the end of the shift
+                if (agentStartTime <= currentHour &&
+                    (agentEndTime - 1 > currentHour ||
+                        (agentEndTime - 1 === currentHour && currentMinute < 30) ||
+                        //below we check if end hour is 10PM CET - but it is 9PM UTC, thus 'agentEndTime  === 21'
+                        (agentEndTime === 21 && currentHour === 20)))
                     /*then*/ currentlyAvailableAgents.push(agents[agent]);
-        }        
+            }
+        }
     }
 
     //then select the agent that should get the ticket assigned
-    
+
     const lastAssignedAgentId = await getLastAssignedAgentId(ticketLevel);
 
     for (let agent in currentlyAvailableAgents) {
-        if (currentlyAvailableAgents[agent].id > lastAssignedAgentId.agentId){
-           return [currentlyAvailableAgents[agent].id, currentlyAvailableAgents[agent].name]
-        } 
+        if (currentlyAvailableAgents[agent].id > lastAssignedAgentId.agentId) {
+            return [currentlyAvailableAgents[agent].id, currentlyAvailableAgents[agent].name]
+        }
     }
 
     if (currentlyAvailableAgents.length > 0)
-    return [currentlyAvailableAgents[0].id, currentlyAvailableAgents[0].name]
+        return [currentlyAvailableAgents[0].id, currentlyAvailableAgents[0].name]
 
     return [undefined, undefined]
 }

--- a/test/selectAgentToAssign.test.ts
+++ b/test/selectAgentToAssign.test.ts
@@ -4,7 +4,7 @@ const testShiftRota =
     {
       date: '22-01-21',
       agents: [ 'Shehroze', 'Phil', 'Kate', 'Hasan', 'Greg', 'Konrad' ],
-      hours: [ '8-16', '', '14-22', '8-14', '8-16', '8-16' ],
+      hours: [ '8-16', '', '14-22', '8-14', '8-10;11-16', '8-16' ],
     }
   
 const mockLastAssignedId = () => {return {agentId: '1'}};
@@ -67,7 +67,5 @@ describe('Test selectAgentToAssign service', () => {
     it('stops assigning tickets to agents 30 minutes before the shift ends', async() => {
         jest.setSystemTime(new Date('2021-01-21 16:30').getTime());
         expect(await selectAgentToAssign(testAgentList, mockLastAssignedId, testShiftRota)).toEqual([5, 'Kate']);
-    });
-
-    
+    });    
 });


### PR DESCRIPTION
Changed the way the agents are selected for being eligible for ticket assignment to handle multiple time periods during the day.

Work time periods can be provided in the shift rota data as semicolon separated values, e.g. '8-10;12-18'